### PR TITLE
v2.11.1-mac-dev

### DIFF
--- a/Text/LLM/model/chatbot/LLM_chatbot_base_info_model.py
+++ b/Text/LLM/model/chatbot/LLM_chatbot_base_info_model.py
@@ -89,6 +89,8 @@ def get_llm_response(prompt: str, category: str) -> Generator[Dict[str, Any], No
     }
 
     response_completed = False  # 응답 완료 여부를 추적하는 플래그
+    token_buffer = ""  # 토큰을 누적할 버퍼
+    word_delimiters = [' ', '\n', '\t', '.', ',', '!', '?', ';', ':', '"', "'", '(', ')', '[', ']', '{', '}', '<', '>', '/', '\\', '|', '&', '*', '+', '-', '=', '_', '@', '#', '$', '%', '^', '~', '`']
 
     try:
         with httpx.stream("POST", url, json=payload, timeout=60.0) as response:
@@ -104,29 +106,57 @@ def get_llm_response(prompt: str, category: str) -> Generator[Dict[str, Any], No
                             if token.strip() in ["```", "`", ""]:
                                 continue  # 이런 토큰은 누적하지 않음
                             full_response += token
+                            token_buffer += token
                             logger.info(f"토큰 수신: {token[:20]}...")
 
-                            # 토큰 정제 - 순수 텍스트만 추출
-                            cleaned_text = token
-                            # JSON 관련 문자열 제거
-                            cleaned_text = re.sub(r'"(recommend|challenges|title|description)":\s*("|\')?', '', cleaned_text)
-                            # 마크다운                                                                                                                                                                                                                                                                                                                                                          및 JSON 구조 제거
-                            cleaned_text = cleaned_text.replace("```json", "").replace("```", "").strip()
-                            cleaned_text = re.sub(r'["\']', '', cleaned_text)  # 따옴표 제거
-                            cleaned_text = re.sub(r'[\[\]{}]', '', cleaned_text)  # 괄호 제거
-                            cleaned_text = re.sub(r',\s*$', '', cleaned_text)  # 끝의 쉼표 제거
-                            cleaned_text = re.sub(r'[ \t\r\f\v]+', ' ', cleaned_text)  # \n은 제거 안 함
-                            
-                            cleaned_text = cleaned_text.strip()
-                            if cleaned_text and cleaned_text.strip() not in ["", "``", "```"] and not response_completed:
-                                yield {
-                                    "event": "challenge",
-                                    "data": json.dumps({
-                                        "status": 200,
-                                        "message": "토큰 생성",
-                                        "data": cleaned_text
-                                    }, ensure_ascii=False)
-                                }
+                            # 토큰 버퍼에서 단어 단위로 분리하여 스트리밍
+                            if any(delimiter in token_buffer for delimiter in word_delimiters):
+                                # 단어 경계를 찾아서 분리
+                                words = []
+                                current_word = ""
+                                for char in token_buffer:
+                                    if char in word_delimiters:
+                                        if current_word:
+                                            words.append(current_word)
+                                            current_word = ""
+                                        words.append(char)
+                                    else:
+                                        current_word += char
+                                
+                                if current_word:
+                                    words.append(current_word)
+                                
+                                # 완성된 단어들만 스트리밍하고, 마지막 불완전한 단어는 버퍼에 유지
+                                if len(words) > 1:
+                                    # 마지막 단어가 불완전할 수 있으므로 제외
+                                    complete_words = words[:-1]
+                                    token_buffer = words[-1] if words else ""
+                                    
+                                    for word in complete_words:
+                                        # 토큰 정제 - 순수 텍스트만 추출
+                                        cleaned_text = word
+                                        # JSON 관련 문자열 제거
+                                        cleaned_text = re.sub(r'"(recommend|challenges|title|description)":\s*("|\')?', '', cleaned_text)
+                                        # 마크다운 및 JSON 구조 제거
+                                        cleaned_text = cleaned_text.replace("```json", "").replace("```", "").strip()
+                                        cleaned_text = re.sub(r'["\']', '', cleaned_text)  # 따옴표 제거
+                                        cleaned_text = re.sub(r'[\[\]{}]', '', cleaned_text)  # 괄호 제거
+                                        cleaned_text = re.sub(r',\s*$', '', cleaned_text)  # 끝의 쉼표 제거
+                                        cleaned_text = re.sub(r'[ \t\r\f\v]+', ' ', cleaned_text)  # \n은 제거 안 함
+                                        
+                                        cleaned_text = cleaned_text.strip()
+                                        if cleaned_text and cleaned_text.strip() not in ["", "``", "```"] and not response_completed:
+                                            yield {
+                                                "event": "challenge",
+                                                "data": json.dumps({
+                                                    "status": 200,
+                                                    "message": "토큰 생성",
+                                                    "data": cleaned_text
+                                                }, ensure_ascii=False)
+                                            }
+                                else:
+                                    # 단어가 하나뿐이면 버퍼에 유지
+                                    pass
                         except Exception as e:
                             logger.error(f"[vLLM 토큰 파싱 실패] {str(e)}")
                             continue
@@ -139,29 +169,57 @@ def get_llm_response(prompt: str, category: str) -> Generator[Dict[str, Any], No
                             if token.strip() in ["```", "`", ""]:
                                 continue  # 이런 토큰은 누적하지 않음
                             full_response += token
+                            token_buffer += token
                             logger.info(f"토큰 수신: {token[:20]}...")
 
-                            # 토큰 정제 - 순수 텍스트만 추출
-                            cleaned_text = token
-                            # JSON 관련 문자열 제거
-                            cleaned_text = re.sub(r'"(recommend|challenges|title|description)":\s*("|\')?', '', cleaned_text)
-                            # 마크다운 및 JSON 구조 제거
-                            cleaned_text = cleaned_text.replace("```json", "").replace("```", "").strip()
-                            cleaned_text = re.sub(r'["\']', '', cleaned_text)  # 따옴표 제거
-                            cleaned_text = re.sub(r'[\[\]{}]', '', cleaned_text)  # 괄호 제거
-                            cleaned_text = re.sub(r',\s*$', '', cleaned_text)  # 끝의 쉼표 제거
-                            cleaned_text = re.sub(r'[ \t\r\f\v]+', ' ', cleaned_text)  # \n은 제거 안 함
-                            
-                            cleaned_text = cleaned_text.strip()
-                            if cleaned_text and cleaned_text.strip() not in ["", "``", "```"] and not response_completed:
-                                yield {
-                                    "event": "challenge",
-                                    "data": json.dumps({
-                                        "status": 200,
-                                        "message": "토큰 생성",
-                                        "data": cleaned_text
-                                    }, ensure_ascii=False)
-                                }
+                            # 토큰 버퍼에서 단어 단위로 분리하여 스트리밍
+                            if any(delimiter in token_buffer for delimiter in word_delimiters):
+                                # 단어 경계를 찾아서 분리
+                                words = []
+                                current_word = ""
+                                for char in token_buffer:
+                                    if char in word_delimiters:
+                                        if current_word:
+                                            words.append(current_word)
+                                            current_word = ""
+                                        words.append(char)
+                                    else:
+                                        current_word += char
+                                
+                                if current_word:
+                                    words.append(current_word)
+                                
+                                # 완성된 단어들만 스트리밍하고, 마지막 불완전한 단어는 버퍼에 유지
+                                if len(words) > 1:
+                                    # 마지막 단어가 불완전할 수 있으므로 제외
+                                    complete_words = words[:-1]
+                                    token_buffer = words[-1] if words else ""
+                                    
+                                    for word in complete_words:
+                                        # 토큰 정제 - 순수 텍스트만 추출
+                                        cleaned_text = word
+                                        # JSON 관련 문자열 제거
+                                        cleaned_text = re.sub(r'"(recommend|challenges|title|description)":\s*("|\')?', '', cleaned_text)
+                                        # 마크다운 및 JSON 구조 제거
+                                        cleaned_text = cleaned_text.replace("```json", "").replace("```", "").strip()
+                                        cleaned_text = re.sub(r'["\']', '', cleaned_text)  # 따옴표 제거
+                                        cleaned_text = re.sub(r'[\[\]{}]', '', cleaned_text)  # 괄호 제거
+                                        cleaned_text = re.sub(r',\s*$', '', cleaned_text)  # 끝의 쉼표 제거
+                                        cleaned_text = re.sub(r'[ \t\r\f\v]+', ' ', cleaned_text)  # \n은 제거 안 함
+                                        
+                                        cleaned_text = cleaned_text.strip()
+                                        if cleaned_text and cleaned_text.strip() not in ["", "``", "```"] and not response_completed:
+                                            yield {
+                                                "event": "challenge",
+                                                "data": json.dumps({
+                                                    "status": 200,
+                                                    "message": "토큰 생성",
+                                                    "data": cleaned_text
+                                                }, ensure_ascii=False)
+                                            }
+                                else:
+                                    # 단어가 하나뿐이면 버퍼에 유지
+                                    pass
                         except Exception as e:
                             logger.error(f"[vLLM 토큰 파싱 실패] {str(e)}")
                             continue

--- a/Text/LLM/requirements.txt
+++ b/Text/LLM/requirements.txt
@@ -158,4 +158,5 @@ bitsandbytes==0.43.1
 rq==2.4.0
 
 # === vLLM ===
-vllm>=0.4.0
+# vLLM은 torch 설치 후 별도 설치 필요
+# vllm


### PR DESCRIPTION
## vLLM 스트리밍 토큰화 방식 문제

### 문제점
- **기존 shared_model 방식**: Transformers의 `TextIteratorStreamer`를 사용해서 **단어 단위**로 토큰화되어 스트리밍됨
- **현재 vLLM 방식**: vLLM의 스트리밍 API를 사용해서 **한 글자씩** 토큰화되어 스트리밍됨
- **사용자 경험**: 클라이언트에서 한 글자씩 출력되어 부자연스러운 스트리밍 경험

**vLLM의 스트리밍 API는 기본적으로 character-level streaming을 제공**하는 반면, Transformers의 `TextIteratorStreamer`는 token-level streaming을 제공

- Transformers TextIteratorStreamer (이전)
    - Token-level streaming = 단어/구 단위로 토큰화
- vLLM 스트리밍 (현재)
    - Character-level streaming = 한 글자씩 토큰화

### 왜 이런 차이가 나는건가?
- vLLM: 내부적으로 더 세밀한 토큰 단위로 처리하여 character-level로 스트리밍
- TextIteratorStreamer: Transformers의 토크나이저가 단어/구 단위로 토큰을 디코딩하여 더 큰 단위로 스트리밍

### 해결책
**FastAPI 서버에서 토큰을 누적해서 단어 단위로 스트리밍하도록 수정**

#### 1. 토큰 버퍼 시스템 구현

#### 2. 단어 구분자 정의

#### 3. 버퍼 관리 로직
- **토큰 누적**: vLLM에서 받은 한 글자씩의 토큰을 `token_buffer`에 누적
- **단어 분리**: 구분자가 나타나면 버퍼를 단어 단위로 분리
- **완성된 단어만 전송**: 마지막 불완전한 단어는 버퍼에 유지하여 다음 토큰과 결합
- **스트리밍**: 완성된 단어들만 클라이언트에 전송