### PR TITLE
v2.13.2-mac-dev

### DIFF
--- a/Text/LLM/model/chatbot/LLM_chatbot_free_text_model.py
+++ b/Text/LLM/model/chatbot/LLM_chatbot_free_text_model.py
@@ -102,7 +102,8 @@ def get_llm_response(prompt: str, category: str) -> Generator[Dict[str, Any], No
     payload = {
         "model": "/home/ubuntu/mistral/models--mistralai--Mistral-7B-Instruct-v0.3/snapshots/e0bc86c23ce5aae1db576c8cca6f06f1f73af2db",
         "messages": [{"role": "user", "content": prompt}],
-        "stream": True
+        "stream": True,
+        "max_tokens":2048
     }
 
     response_completed = False  # 응답 완료 여부를 추적하는 플래그
@@ -212,22 +213,61 @@ def get_llm_response(prompt: str, category: str) -> Generator[Dict[str, Any], No
             json_str = re.sub(r',\s*,', ',', json_str)
             json_str = re.sub(r'[ \t\r\f\v]+', ' ', json_str)
             logger.info(f"파싱 시도 문자열: {json_str}")
-            parsed_temp = json.loads(json_str)
-            parsed_data = rag_parser.parse(json.dumps(parsed_temp))
-            eng_label = label_mapping[category]
-            if isinstance(parsed_data, dict) and "challenges" in parsed_data:
-                for challenge in parsed_data["challenges"]:
-                    challenge["category"] = eng_label
-            if not response_completed:
-                response_completed = True
-                yield {
-                    "event": "close",
-                    "data": json.dumps({
-                        "status": 200,
-                        "message": "모든 챌린지 추천 완료",
-                        "data": parsed_data
-                    }, ensure_ascii=False)
+            
+            # JSON 파싱 시도
+            try:
+                parsed_temp = json.loads(json_str)
+                # rag_parser.parse() 안전하게 처리
+                try:
+                    parsed_data = rag_parser.parse(json.dumps(parsed_temp))
+                except Exception as parse_error:
+                    logger.error(f"rag_parser.parse() 실패: {str(parse_error)}")
+                    # fallback: 기본 구조로 변환
+                    if isinstance(parsed_temp, dict):
+                        parsed_data = {
+                            "recommend": parsed_temp.get("recommend", "챌린지를 추천합니다."),
+                            "challenges": parsed_temp.get("challenges", [])
+                        }
+                    else:
+                        # 완전한 fallback
+                        parsed_data = {
+                            "recommend": "챌린지를 추천합니다.",
+                            "challenges": []
+                        }
+                
+                # 카테고리 정보 추가
+                eng_label = label_mapping[category]
+                if isinstance(parsed_data, dict) and "challenges" in parsed_data:
+                    for challenge in parsed_data["challenges"]:
+                        challenge["category"] = eng_label
+                
+                if not response_completed:
+                    response_completed = True
+                    yield {
+                        "event": "close",
+                        "data": json.dumps({
+                            "status": 200,
+                            "message": "모든 챌린지 추천 완료",
+                            "data": parsed_data
+                        }, ensure_ascii=False)
+                    }
+            except json.JSONDecodeError as json_error:
+                logger.error(f"JSON 파싱 실패: {str(json_error)}")
+                # JSON이 아닌 경우 fallback
+                parsed_data = {
+                    "recommend": full_response.strip(),
+                    "challenges": []
                 }
+                if not response_completed:
+                    response_completed = True
+                    yield {
+                        "event": "close",
+                        "data": json.dumps({
+                            "status": 200,
+                            "message": "모든 챌린지 추천 완료",
+                            "data": parsed_data
+                        }, ensure_ascii=False)
+                    }
         except Exception as e:
             logger.error(f"[vLLM 파싱 실패] {str(e)}")
             logger.error(f"원본 응답: {full_response[:500]}...")

--- a/Text/LLM/start_services.sh
+++ b/Text/LLM/start_services.sh
@@ -93,14 +93,14 @@ echo -e "${YELLOW}4. vLLM 서버 시작 중...${NC}"
 if check_port 8800; then
     echo -e "${GREEN}vLLM 서버가 이미 실행 중입니다 (포트 8800)${NC}"
 else
-    # vLLM 서버 백그라운드 실행
+    # vLLM 서버 백그라운드 실행 (KV 캐시 부족 문제 해결을 위한 파라미터 추가)
     nohup python -m vllm.entrypoints.openai.api_server \
         --model /home/ubuntu/mistral/models--mistralai--Mistral-7B-Instruct-v0.3/snapshots/e0bc86c23ce5aae1db576c8cca6f06f1f73af2db \
         --host 0.0.0.0 \
-        --port 8800
+        --port 8800 \
+        --max-model-len 8192 \
+        --gpu-memory-utilization 0.9
         # --tensor-parallel-size 1 \
-        # --gpu-memory-utilization 0.8 \
-        # --max-model-len 4096 \
         # --enforce-eager \
         > $LOG_DIR/vllm.log 2>&1 &
     


### PR DESCRIPTION
1. vLLM 서버 시작 명령어 수정
  -   `--max-model-len 8192`  & `--gpu-memory-utilization 0.9` 추가
   ```bash
   python3 -m vllm.entrypoints.openai.api_server \
       --model /home/ubuntu/mistral/models--mistralai--Mistral-7B-Instruct-v0.3/snapshots/e0bc86c23ce5aae1db576c8cca6f06f1f73af2db \
       --host 0.0.0.0 \
       --port 8800 \
       --max-model-len 8192 \
       --gpu-memory-utilization 0.9
   ```
2. JSON 파싱 실패로 인한 `'str' object does not support item assignment` 에러 발생
  - 다층 예외 처리 적용
    - **JSON 파싱 실패**: `json.JSONDecodeError`로 처리하여 fallback 로직 실행
    - **Parser 파싱 실패**: `base_parser.parse()` 또는 `rag_parser.parse()` 실패 시 기본. 구조로 변환
    - **완전한 fallback**: 모든 파싱이 실패해도 기본 응답 구조 제공
3. vLLM EngineGenerateError 및 Invalid prefix 장애
  - vLLM애소 max_tokens 값이 32247로 매우 크게 설정되어 있어, 비정상적인 토큰 시퀀스가 생성될 가능성 확인
  - max_tokens 값을 2048로 제한
  - 근거:
  ```text
  한국어 1토큰 ≈ 1글자 (대략적으로)
  실제 프롬프트 토큰 수:
  시스템 프롬프트: ~600 토큰
  사용자 입력: ~50 토큰
  총 입력: ~650 토큰
  응답 토큰 수:
  3개 챌린지 × (제목 + 설명): ~200-300 토큰
  JSON 구조: ~100 토큰
  총 응답: ~300-400 토큰
  총 출력: ~400 토큰
  총 사용량: ~1050 토큰
  ```