### PR TITLE
v2.13.4-mac-dev

### DIFF
--- a/Text/LLM/model/chatbot/troubleshooting_chatbot.md
+++ b/Text/LLM/model/chatbot/troubleshooting_chatbot.md
@@ -2296,3 +2296,21 @@ except json.JSONDecodeError as json_error:
 - **상세한 오류 로깅**: 문제 발생 시 원인 파악 용이
 - **단계별 추적**: JSON 파싱 → Parser 파싱 → fallback 순서로 문제 추적
 - **원본 데이터 보존**: 실패한 JSON 문자열 로깅으로 원인 분석 가능
+
+# 2025-07-21 챗봇 프롬프트 및 라우터 코드 개선 내역
+
+## 1. 챗봇 프롬프트(LLM_chatbot_base_info_model.py, LLM_chatbot_free_text_model.py) 변경
+- 프롬프트를 **한글 100%**로, recommend/challenges 등 모든 출력이 반드시 한글로만 나오도록 강하게 명시
+- 반드시 하나의 올바른 JSON 객체만 출력, recommend(문자열)와 challenges(객체 배열)만 최상위 필드로
+- challenges 각 항목의 title/description도 한글로만, 영어/숫자/특수문자/이모지/마크다운/코드블록 등 사용 금지
+- JSON 외의 어떤 텍스트도 출력 금지, recommend/challenges 중첩/문자열 등 잘못된 구조 방지
+- 예시 출력({escaped_format}) 포함, 프롬프트 내 지침 강화
+
+## 2. 라우터 코드(chatbot_router.py) 변경
+- SSE 응답에서 LLM 응답 파싱 및 검증 로직 개선
+- event: "challenge"/"close"/"error" 등 이벤트별로 JSON 파싱 및 에러 처리 강화
+- 최종 응답에서 반드시 challenges가 리스트로 포함되어 있는지 검증
+- base-info/free-text 모두 동일한 구조로 챌린지 추천 결과 반환
+- 대화 기록/세션 관리 및 카테고리 처리 로직 개선
+
+---

--- a/Text/LLM/normalize_and_generate_multitask_dataset.py
+++ b/Text/LLM/normalize_and_generate_multitask_dataset.py
@@ -1,0 +1,288 @@
+import json
+import random
+import re
+import copy
+import datetime
+from pathlib import Path
+
+# 데이터 생성 관련 상수 및 샘플
+locations = ["도시", "바닷가", "산", "농촌"]
+work_types = ["사무직", "현장직", "영업직", "재택근무"]
+categories = [
+    "제로웨이스트", "플로깅", "탄소발자국", "에너지 절약",
+    "업사이클", "문화 공유", "디지털 탄소", "비건"
+]
+free_text_inputs = [
+    "요즘 너무 피곤해서 아무것도 하기 싫어.",
+    "환경을 위해 내가 할 수 있는 게 뭐가 있을까?",
+    "친구랑 같이 할만한 챌린지 추천해줘.",
+    "집에서 할 수 있는 친환경 활동 알려줘.",
+    "오늘 날씨가 너무 더워서 힘들어.",
+    "회사에서 쉽게 실천할 수 있는 환경 챌린지 뭐 있어?",
+    "반려동물이랑 같이 할 수 있는 활동 알려줘.",
+    "스트레스 받을 때 할만한 친환경 챌린지 추천해줘."
+]
+free_text_recommends = [
+    "상황에 맞는 친환경 챌린지를 추천해 드릴게요!",
+    "이럴 때 실천하면 좋은 친환경 챌린지 3가지를 알려드릴게요!",
+    "기분 전환과 환경 보호를 동시에 할 수 있는 챌린지입니다!",
+    "일상에서 쉽게 실천할 수 있는 친환경 챌린지를 추천합니다!",
+    "함께하면 더 즐거운 친환경 챌린지 3가지를 소개할게요!"
+]
+free_text_challenges = [
+    {"title": "1. 햇볕 쬐며 10분 산책하기", "description": "점심시간에 잠시 공원을 걸으며 비타민 D를 보충하고 기분을 전환해보세요."},
+    {"title": "2. 건강한 채소 주스 마시기", "description": "신선한 채소와 과일로 만든 주스로 몸에 생기를 불어넣어요."},
+    {"title": "3. 숙면을 위한 디지털 디톡스", "description": "잠들기 1시간 전에는 스마트폰을 멀리하고 편안한 휴식을 취해보세요."},
+    {"title": "4. 환경 다큐멘터리 시청하기", "description": "환경을 주제로 한 다큐멘터리를 감상해보세요."},
+    {"title": "5. 플로깅 참여하기", "description": "산책이나 운동할 때 주변 쓰레기를 주워보세요."},
+    {"title": "6. 텀블러 사용하기", "description": "일회용 컵 대신 텀블러를 사용해보세요."},
+    {"title": "7. 채식 식단 도전하기", "description": "일주일에 하루는 채식 식단에 도전해보세요."},
+    {"title": "8. 중고 거래 앱 이용하기", "description": "필요한 물건은 중고 거래 앱에서 찾아보세요."},
+    {"title": "9. 다회용기 사용하기", "description": "포장 음식 주문 시 다회용기를 사용해보세요."},
+    {"title": "10. 실내 적정 온도 유지하기", "description": "여름엔 26도, 겨울엔 20도로 실내 온도를 유지해보세요."},
+    {"title": "11. 반려동물과 플로깅하기", "description": "반려동물과 산책하며 쓰레기를 주워보세요."},
+    {"title": "12. 업사이클링 공예 도전하기", "description": "집에 있는 재료로 업사이클링 소품을 만들어보세요."}
+]
+feedback_titles = [
+    "텀블러 사용하기", "음식 남기지 않기", "대중교통 이용하기", "계단 이용하기", "플로깅 참여하기", "비건 식단 도전하기",
+    "쓰레기 줍기", "에코백 사용하기", "자전거 타기", "손수건 사용", "재활용 분리수거", "도시락 싸먹기"
+]
+group_titles = [
+    "비건데이", "플로깅", "도시락 싸먹기", "에코백 사용하기", "종이컵 대신 머그컵", "환경 다큐 시청"
+]
+success_emojis = ["🌱", "🎉", "👍", "✨"]
+fail_emojis = ["😅", "😢", "😭"]
+encourage_emojis = ["💪", "💖", "😊", "👏"]
+
+challenge_title_templates = [
+    "{num}. {category} 실천하기",
+    "{num}. {category} 챌린지 도전",
+    "{num}. {category} 관련 활동",
+    "{num}. {category} 습관 만들기",
+    "{num}. {category} 미션",
+    "{num}. {category} 함께 해요"
+]
+challenge_desc_templates = [
+    "{location}에서 {work_type}이 할 수 있는 {category} 챌린지입니다.",
+    "{work_type} 환경에서 실천할 수 있는 {category} 활동을 해보세요.",
+    "동료들과 {category} 팁을 공유하며 함께 실천해보세요.",
+    "오늘은 {category}에 한 번 도전해보는 건 어때요?",
+    "작은 실천이 큰 변화를 만듭니다! {category}에 도전해보세요.",
+    "{category}로 환경을 지키는 멋진 하루를 만들어보세요."
+]
+challenge_recommend_templates = [
+    "{location}, {work_type}, {category}에 어울리는 친환경 챌린지 3가지를 추천합니다!",
+    "{location}에서 {work_type}에게 딱 맞는 {category} 챌린지 세 가지!",
+    "{work_type}이(가) {location}에서 실천할 수 있는 {category} 미션을 소개할게요.",
+    "{category}에 관심 있는 {work_type}에게 추천하는 챌린지 TOP 3!",
+    "{location} 라이프스타일에 맞는 {category} 챌린지, 지금 시작해보세요!"
+]
+free_text_recommend_templates = [
+    "상황에 맞는 친환경 챌린지를 추천해 드릴게요!",
+    "이럴 때 실천하면 좋은 친환경 챌린지 3가지를 알려드릴게요!",
+    "기분 전환과 환경 보호를 동시에 할 수 있는 챌린지입니다!",
+    "일상에서 쉽게 실천할 수 있는 친환경 챌린지를 추천합니다!",
+    "함께하면 더 즐거운 친환경 챌린지 3가지를 소개할게요!",
+    "오늘은 이런 챌린지에 도전해보는 건 어떨까요?",
+    "작은 실천이 큰 변화를 만듭니다!",
+    "환경을 생각하는 당신께 드리는 챌린지 제안입니다!"
+]
+
+def pick_emoji(pool):
+    return random.choice(pool)
+
+def random_date(start_year=2025, end_year=2026):
+    start = datetime.date(start_year, 1, 1)
+    end = datetime.date(end_year, 12, 31)
+    delta = end - start
+    random_days = random.randint(0, delta.days)
+    d = start + datetime.timedelta(days=random_days)
+    return d.strftime("%Y-%m-%dT%H:%M:%S")
+
+def generate_challenge_items(existing, target):
+    combos = [(l, w, c) for l in locations for w in work_types for c in categories]
+    used = set((item["input"].strip(),) for item in existing)
+    new_items = []
+    for l, w, c in combos:
+        key = f"{l}, {w}, {c}"
+        if (key,) in used:
+            continue
+        # 다양한 템플릿 랜덤 적용
+        recommend = random.choice(challenge_recommend_templates).format(location=l, work_type=w, category=c)
+        challenges = [
+            {
+                "title": random.choice(challenge_title_templates).format(num=idx+1, category=c),
+                "description": random.choice(challenge_desc_templates).format(location=l, work_type=w, category=c)
+            }
+            for idx in range(3)
+        ]
+        # 무조건 줄바꿈 문자열 포맷
+        challenge_lines = [f"{ch['title']}: {ch['description']}" for ch in challenges]
+        output_text = recommend + "\n" + "\n".join(challenge_lines)
+        new_items.append({
+            "instruction": "너는 챌린지 추천 챗봇이야. 사용자가 선택한 '위치, 직업, 카테고리'에 맞춰 구체적인 친환경 챌린지 3가지를 줄바꿈(\\n)으로 구분해서 추천해줘.",
+            "input": key,
+            "output": output_text
+        })
+        if len(existing) + len(new_items) >= target:
+            break
+    return existing + new_items[:max(0, target - len(existing))]
+
+def generate_feedback_items(existing, target):
+    new_items = []
+    for i in range(target - len(existing)):
+        member_id = random.randint(100, 999)
+        n_personal = random.randint(0, 3)
+        personal = []
+        for _ in range(n_personal):
+            title = random.choice(feedback_titles)
+            is_success = random.choice([True, False])
+            personal.append({
+                "id": random.randint(1, 999),
+                "title": title,
+                "isSuccess": is_success
+            })
+        n_group = random.randint(0, 2)
+        group = []
+        for _ in range(n_group):
+            title = random.choice(group_titles)
+            start = random_date()
+            end = random_date()
+            if end < start:
+                start, end = end, start
+            n_sub = random.randint(0, 3)
+            submissions = []
+            for _ in range(n_sub):
+                submissions.append({
+                    "isSuccess": random.choice([True, False]),
+                    "submittedAt": random_date()
+                })
+            group.append({
+                "id": random.randint(100, 999),
+                "title": title,
+                "startDate": start,
+                "endDate": end,
+                "submissions": submissions
+            })
+        inp = json.dumps({
+            "memberId": member_id,
+            "personalChallenges": personal,
+            "groupChallenges": group
+        }, ensure_ascii=False)
+        successes = [c["title"] for c in personal if c["isSuccess"]]
+        fails = [c["title"] for c in personal if not c["isSuccess"]]
+        group_titles_done = [g["title"] for g in group if any(s["isSuccess"] for s in g["submissions"])]
+        group_titles_none = [g["title"] for g in group if not g["submissions"]]
+        msg = []
+        if successes:
+            msg.append(f"{', '.join(successes)} 성공! 정말 멋져요. {pick_emoji(success_emojis)}")
+        if fails:
+            msg.append(f"{', '.join(fails)}는(은) 조금 아쉬웠지만, 도전 자체가 의미 있어요. {pick_emoji(fail_emojis)}")
+        if group_titles_done:
+            msg.append(f"{', '.join(group_titles_done)} 챌린지에도 꾸준히 참여하셨네요! 대단해요. {pick_emoji(success_emojis)}")
+        if group_titles_none:
+            msg.append(f"{', '.join(group_titles_none)} 챌린지는 아직 참여 기록이 없어요. 다음엔 꼭 도전해봐요! {pick_emoji(encourage_emojis)}")
+        if not msg:
+            msg.append(f"이번 주는 챌린지 활동이 없었네요. 다음엔 새로운 도전을 기대할게요! {pick_emoji(encourage_emojis)}")
+        msg_joined = " ".join(msg)
+        sentences = re.split(r'(?<=[.!?]) +', msg_joined)
+        out = ""
+        for s in sentences:
+            if len(out) + len(s) > 200:
+                break
+            out += s + " "
+        out = out.strip()
+        new_items.append({
+            "instruction": "너는 피드백 어시스턴트야. 아래와 같은 JSON 입력을 받으면, 사용자의 챌린지 활동을 요약해서 칭찬과 격려를 해줘. 한글로, 200자 이내로 답해.",
+            "input": inp,
+            "output": out
+        })
+    return existing + new_items
+
+def generate_free_text_items(existing, target):
+    new_items = []
+    for i in range(target - len(existing)):
+        inp = random.choice(free_text_inputs)
+        recommend = random.choice(free_text_recommend_templates)
+        challenges = random.sample(free_text_challenges, 3)
+        challenge_lines = [
+            f"{idx+1}. {c['title'].split('. ', 1)[-1]}: {c['description']}" for idx, c in enumerate(challenges)
+        ]
+        output_text = recommend + "\n" + "\n".join(challenge_lines)
+        new_items.append({
+            "instruction": "너는 사용자와 자유롭게 대화하며 대화의 맥락에 맞는 친환경 챌린지 3가지를 줄바꿈(\\n)으로 구분해서 추천하는 챗봇이야.",
+            "input": inp,
+            "output": output_text
+        })
+    return existing + new_items
+
+def parse_output_to_object(data):
+    for item in data:
+        if "output" in item:
+            try:
+                if isinstance(item["output"], str) and item["output"].strip().startswith("{") and item["output"].strip().endswith("}"):
+                    item["output"] = json.loads(item["output"])
+            except Exception as e:
+                print("Error parsing output:", item["output"])
+                raise e
+    return data
+
+def fix_challenge_title_numbering(data):
+    for item in data:
+        out = item.get("output")
+        if isinstance(out, dict) and "challenges" in out:
+            for idx, challenge in enumerate(out["challenges"], 1):
+                old_title = challenge.get("title", "")
+                new_title = re.sub(r"^\d+\.\s*", "", old_title)
+                challenge["title"] = f"{idx}. {new_title}"
+    return data
+
+def save_json(data, path):
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(data, f, ensure_ascii=False, indent=2)
+
+def force_output_to_string(data):
+    for item in data:
+        if isinstance(item["output"], dict):
+            item["output"] = json.dumps(item["output"], ensure_ascii=False)
+    return data
+
+def main():
+    # 기존 데이터 로드
+    DATASET_PATH = Path("multitask_dataset_2000+300.json")
+    with open(DATASET_PATH, encoding="utf-8") as f:
+        data = json.load(f)
+    # 유형별 목표 개수
+    TARGET_SIZE = 10000
+    n_types = 3
+    per_type = TARGET_SIZE // n_types
+    extra = TARGET_SIZE - per_type * n_types
+    type_targets = [per_type] * n_types
+    for i in range(extra):
+        type_targets[i] += 1
+    # 기존 데이터 분류
+    challenge_items = [x for x in data if '챌린지 추천' in x['instruction']]
+    free_text_items = [x for x in data if '자유롭게 대화' in x['instruction']]
+    feedback_items = [x for x in data if '피드백 어시스턴트' in x['instruction']]
+    # 부족분 생성
+    new_challenge = generate_challenge_items(challenge_items, type_targets[0])
+    new_free_text = generate_free_text_items(free_text_items, type_targets[1])
+    new_feedback = generate_feedback_items(feedback_items, type_targets[2])
+    # 합치기 및 셔플
+    all_items = challenge_items + new_challenge + free_text_items + new_free_text + feedback_items + new_feedback
+    random.shuffle(all_items)
+    all_items = all_items[:TARGET_SIZE]
+    # save_json(all_items, "Text/LLM/step1_balanced.json")
+    # output 오브젝트 변환
+    data_obj = parse_output_to_object(copy.deepcopy(all_items))
+    # save_json(data_obj, "Text/LLM/step2_output_object.json")
+    # 챌린지 타이틀 번호 정규화
+    data_numbered = fix_challenge_title_numbering(copy.deepcopy(data_obj))
+    data_stringified = force_output_to_string(data_numbered)
+    # save_json(data_numbered, "Text/LLM/step3_output_object_numbered.json")
+    # 최종 저장
+    save_json(data_stringified, "multitask_dataset_v2.json")
+    print(f"Done. Saved to Text/LLM/multitask_dataset_v2.json")
+
+if __name__ == "__main__":
+    main() 

--- a/Text/LLM/router/chatbot_router.py
+++ b/Text/LLM/router/chatbot_router.py
@@ -1,5 +1,5 @@
 # chatbot_router.py
-from ..model.chatbot.LLM_chatbot_base_info_model import base_prompt, get_llm_response as get_base_info_llm_response, base_parser
+from ..model.chatbot.LLM_chatbot_base_info_model import base_prompt, get_llm_response as get_base_info_llm_response, base_parser, escaped_format
 from ..model.chatbot.LLM_chatbot_free_text_model import process_chat, clear_conversation, conversation_states, custom_prompt, get_llm_response as get_free_text_llm_response, retriever
 from ..model.chatbot.chatbot_constants import label_mapping, ENV_KEYWORDS, BAD_WORDS
 from fastapi import APIRouter, Query, HTTPException
@@ -89,7 +89,8 @@ async def select_category(
     prompt = base_prompt.format(
         location=location,
         workType=workType,
-        category=category
+        category=category,
+        escaped_format=escaped_format
     )
 
     # SSE 응답 생성
@@ -257,7 +258,8 @@ async def freetext_rag(
             context=context,  # RAG 활성화
             query=message,
             messages=messages_history,
-            category=current_category
+            category=current_category,
+            escaped_format=escaped_format
         )
 
         # LLM 응답 스트리밍

--- a/Text/LLM/troubleshooting_finetunning.md
+++ b/Text/LLM/troubleshooting_finetunning.md
@@ -1,0 +1,218 @@
+# LLM 파인튜닝 트러블슈팅 (Troubleshooting Fine-tuning)
+
+data[25-07-15]
+
+## 1. Loss가 잘 안 줄어드는 경우
+- **데이터셋이 너무 작거나 중복/유사 데이터가 많음**
+  - 더 많은 데이터, 다양한 상황/문장/피드백 패턴 추가
+- **output이 너무 짧거나 단순**
+  - 다양한 문장 구조, 이모지, 피드백 스타일 추가
+- **output이 항상 비슷한 패턴**
+  - recommend/칭찬 멘트 pool, challenge title/description pool 확장
+- **하이퍼파라미터 문제**
+  - learning rate, batch size, optimizer, scheduler 등 조정
+
+## 2. 데이터 품질 문제
+- **output이 JSON 형식이 아니거나, 필드 누락**
+  - output 구조 일관성 체크 (recommend, challenges, title, description 등)
+- **피드백 output이 100자 초과**
+  - 길이 제한 로직 추가, 자연스러운 축약/요약
+- **이모지/문장 다양성 부족**
+  - 다양한 이모지, 문장 템플릿 활용
+
+## 3. 모델/토크나이저 이슈
+- **토크나이저가 특수문자/이모지 처리 못함**
+  - 토크나이저 vocab 확장, pre-tokenization 확인
+- **output이 깨지거나 잘림**
+  - max_length, truncation 등 파라미터 확인
+
+## 4. 기타
+- **학습이 너무 빨리 끝남/과적합**
+  - early stopping, validation split, regularization 적용
+- **실제 inference 시 output이 기대와 다름**
+  - instruction/input/output 예시 다양화, prompt engineering
+
+---
+
+> **실전 팁**
+> - 데이터셋을 늘릴 때는 기존 output pool에서 변형/조합, 랜덤 샘플링, 템플릿 변형을 적극 활용
+> - 피드백 output은 100자 이내, 나머지는 기존 패턴 유지
+> - loss가 plateau에 머물면 데이터/하이퍼파라미터/모델 구조 모두 점검 
+
+data[25-07-17]
+
+# 25-07-17 토크나이저 config 및 vLLM 관련 트러블슈팅
+
+- 이 섹션은 2025-07-17에 발생한 토크나이저 및 vLLM 관련 문제와 해결 과정을 상세히 기록합니다.
+
+## 1. vLLM에서 TypeError: expected str, bytes or os.PathLike object, not NoneType 에러 발생
+
+### 문제점
+- vLLM 실행 시 토크나이저 로딩에서 TypeError 발생
+
+### 원인 분석
+- tokenizer_config.json에 "tokenizer_file" 또는 "vocab_file" 항목이 없어서, transformers/vLLM이 tokenizer.model 파일을 자동으로 못 찾음
+
+### 해결책
+- tokenizer_config.json에 반드시 "tokenizer_file": "tokenizer.model" 또는 "vocab_file": "tokenizer.model" 추가
+
+---
+
+## 2. eos_token 값이 " "(공백)으로 잘못 설정된 경우
+
+### 문제점
+- 파인튜닝/수동 config 수정 시 실수로 "eos_token": " "로 바뀜
+
+### 원인 분석
+- 문장 종료가 제대로 인식되지 않아 출력이 비정상적으로 길어지거나, 디코더가 오작동
+
+### 해결책
+- 반드시 "eos_token": "</s>"로 설정
+
+---
+
+## 3. 원본 모델은 config에 tokenizer_file이 없어도 동작하는데, 파인튜닝/수동 모델은 왜 필요?
+
+### 문제점
+- 원본 모델은 config에 tokenizer_file이 없어도 동작, 파인튜닝/수동 모델은 에러 발생
+
+### 원인 분석
+- 원본 모델은 Hugging Face 표준 구조라 transformers가 자동 인식, 파인튜닝/수동 복사 모델은 구조가 미묘하게 다를 수 있어 명시 필요
+
+### 해결책/팁
+- 파인튜닝/수동 모델은 config에 명시적으로 경로를 적어주는 것이 가장 안전함
+
+---
+
+data[25-07-18]
+
+# 25-07-18 vLLM device-side assert 및 파인튜닝 품질 문제 트러블슈팅
+
+- 이 섹션은 2025-07-18에 발생한 vLLM device-side assert 문제와 파인튜닝 결과 품질 문제를 상세히 기록합니다.
+
+## 1. vLLM에서 CUDA device-side assert triggered 에러 발생
+
+### 문제점
+- vLLM 서버는 정상 기동되지만, inference 요청 시 "CUDA error: device-side assert triggered" 에러 발생
+- transformers에서는 정상 동작하지만 vLLM에서만 에러 발생
+
+### 원인 분석
+- **모델/토크나이저/config 파일 mismatch**: merge된 모델의 config, tokenizer 파일이 base 모델과 다름
+- **vLLM의 엄격한 GPU 커널 체크**: transformers는 fallback이 있지만 vLLM은 GPU에서 엄격하게 체크
+- **LoRA merge 후 config/tokenizer 파일 누락**: merge_and_unload()는 weight만 합치고, config/tokenizer는 별도로 base와 동일하게 맞춰야 함
+
+### 해결책
+1. **base 모델의 config/tokenizer 파일을 merge된 모델에 덮어쓰기**
+   - config.json, tokenizer_config.json, generation_config.json
+   - tokenizer.model, tokenizer.json, special_tokens_map.json
+2. **tokenizer_config.json에 "tokenizer_file": "tokenizer.model" 추가**
+3. **모든 파일이 base 모델과 완전히 동일한지 확인**
+
+### 핵심 원리
+- **LoRA merge는 weight만 합치는 것**: 구조(config), 토크나이저는 base와 동일해야 함
+- **vLLM은 GPU 커널에서 엄격하게 체크**: config/tokenizer mismatch가 있으면 바로 device-side assert 발생
+
+---
+
+## 2. 파인튜닝 결과 품질 문제 (한글 토큰화, 이상한 출력)
+
+### 문제점
+- 출력이 이상함: "힐링할수있는시는건강!" (띄어쓰기 없음)
+- 이상한 토큰: "Band", "공HED", "abandon", "anonymousanimal" 등
+- 문맥 부족: 제대로 된 챌린지가 아닌 이상한 텍스트
+
+### 원인 분석
+- **한글 토큰화 문제**: 토크나이저가 한글 띄어쓰기를 제대로 처리하지 못함
+- **데이터셋 품질**: 학습 데이터의 한글 띄어쓰기, 문장 구조가 부족
+- **파인튜닝 파라미터**: learning rate, epochs, batch size 등이 최적화되지 않음
+
+### 해결책
+1. **데이터셋 품질 개선**
+   - 한글 띄어쓰기 정확히: "힐링할 수 있는 시는 건강!"
+   - 더 구체적이고 현실적인 챌린지 예시 추가
+   - JSON 형식 엄격하게 지키기
+2. **파인튜닝 파라미터 조정**
+   - learning_rate: 더 작게 (예: 1e-4 → 5e-5)
+   - epochs: 더 많이 (예: 3 → 5-10)
+   - batch_size: 메모리 허용시 더 크게
+3. **프롬프트 개선**
+   - 더 명확한 instruction
+   - 예시 포함 (few-shot learning)
+
+---
+
+## 3. 왜 merge된 모델의 config/tokenizer가 base와 동일해야 하나?
+
+### 핵심 원리
+- **LoRA는 "가중치만" 수정하는 방식**: 모델 구조(config), 토크나이저는 그대로 유지
+- **merge_and_unload()는 weight만 base에 합치는 것**: config/tokenizer는 별도로 base와 동일하게 맞춰야 함
+- **vLLM의 엄격한 요구사항**: GPU 커널에서 정확한 구조 정보를 요구, config.json의 vocab_size, hidden_size, num_attention_heads 등이 weight 파일과 1:1로 일치해야 함
+
+### transformers vs vLLM 차이
+- **transformers**: 내부적으로 fallback/에러 무시 가능
+- **vLLM**: GPU 커널에서 엄격하게 체크 → 조금이라도 다르면 바로 device-side assert 발생
+
+---
+
+## 현재 상태
+- vLLM device-side assert 문제는 해결됨
+- 파인튜닝 결과 품질 개선 필요 (한글 토큰화, 데이터셋 품질, 파라미터 튜닝)
+- config/tokenizer를 base와 동일하게 맞추는 것이 핵심임을 확인 
+
+data[25-07-20]
+
+# 25-07-20 데이터셋 포맷 다양성(줄바꿈/JSON) 혼합 이슈 (최신 코드 반영)
+
+## 문제점 (이전)
+- 자유채팅/챌린지 추천 데이터셋의 output 포맷이 줄바꿈(\n) 문자열과 JSON 문자열이 혼합되어 있었음
+- 파인튜닝/추론 시 모델이 다양한 포맷(줄바꿈/JSON)으로 답변을 생성함
+- 실제 서비스에서 output 포맷이 일관되지 않아 후처리/파싱 로직이 복잡해질 수 있었음
+
+## 원인 분석 (이전)
+- 데이터 생성 코드(`normalize_and_generate_multitask_dataset.py`)에서 챌린지 추천 output 포맷을 랜덤(50%)으로 줄바꿈 문자열 또는 JSON 문자열로 생성하도록 설계함
+- 목적: 데이터 다양성, 실제 서비스에서의 포맷 적응력 향상, 프롬프트/실전 상황에서 모델이 여러 포맷을 유연하게 생성할 수 있도록 하기 위함
+- 하지만, 한 포맷만 원하는 경우에는 혼합이 오히려 불편할 수 있었음
+
+## 해결책 (최신)
+- **2025-07-20 코드 변경:** 챌린지 추천 데이터의 output 포맷을 무조건 줄바꿈(\n) 문자열로만 생성하도록 코드 수정
+  - `generate_challenge_items` 함수에서 if문/else문 제거, 항상 줄바꿈 포맷만 생성
+  - 예시:
+    ```python
+    challenge_lines = [f"{ch['title']}: {ch['description']}" for ch in challenges]
+    output_text = recommend + "\n" + "\n".join(challenge_lines)
+    ```
+- 최종 저장 파일명도 `multitask_dataset_final.json` → `multitask_dataset_v2.json`으로 변경
+- 자유채팅(프리텍스트) 데이터도 이미 줄바꿈 포맷만 생성하도록 유지
+- 데이터셋 생성 시 output 포맷을 일관되게 맞추면 모델이 해당 포맷을 더 잘 따라함
+- 서비스 요구사항에 따라 포맷 일관성(파싱/후처리 단순화) 또는 다양성(모델 적응력 강화) 중 선택 가능
+
+## 실전 사례/운영 경험 (최신)
+- **실제 운영 중**: output 포맷이 혼합되어 있을 때, 프론트엔드/백엔드에서 파싱 로직이 복잡해지고, 예외 케이스(예: 줄바꿈 포맷인데 JSON 파싱 시도, JSON인데 줄바꿈 split 시도 등)에서 오류가 발생할 수 있었음
+- **코드 수정 후**: 챌린지 추천/프리텍스트 output이 모두 줄바꿈 포맷으로 통일되어, 후처리/파싱 로직이 단순해지고, 운영 안정성 향상
+- **실전 팁**: 데이터셋을 늘릴 때는 기존 output pool에서 변형/조합, 랜덤 샘플링, 템플릿 변형을 적극 활용하고, 후처리 로직을 반드시 준비할 것
+
+## 현재 상태 (2025-07-20 기준)
+- 챌린지 추천/프리텍스트 데이터의 output이 모두 줄바꿈(\n) 포맷으로 통일됨
+- 최종 데이터셋 파일: `multitask_dataset_v2.json`
+- 모델이 일관된 포맷을 학습/생성하므로 서비스 후처리/파싱이 매우 단순해짐
+- 필요시 포맷 다양성(혼합)도 코드 수정으로 쉽게 적용 가능
+
+--- 
+
+# 2025-07-21 챗봇 프롬프트 및 라우터 코드 개선 내역
+
+## 1. 챗봇 프롬프트(LLM_chatbot_base_info_model.py, LLM_chatbot_free_text_model.py) 변경
+- 프롬프트를 **한글 100%**로, recommend/challenges 등 모든 출력이 반드시 한글로만 나오도록 강하게 명시
+- 반드시 하나의 올바른 JSON 객체만 출력, recommend(문자열)와 challenges(객체 배열)만 최상위 필드로
+- challenges 각 항목의 title/description도 한글로만, 영어/숫자/특수문자/이모지/마크다운/코드블록 등 사용 금지
+- JSON 외의 어떤 텍스트도 출력 금지, recommend/challenges 중첩/문자열 등 잘못된 구조 방지
+- 예시 출력({escaped_format}) 포함, 프롬프트 내 지침 강화
+
+## 2. 라우터 코드(chatbot_router.py) 변경
+- SSE 응답에서 LLM 응답 파싱 및 검증 로직 개선
+- event: "challenge"/"close"/"error" 등 이벤트별로 JSON 파싱 및 에러 처리 강화
+- 최종 응답에서 반드시 challenges가 리스트로 포함되어 있는지 검증
+- base-info/free-text 모두 동일한 구조로 챌린지 추천 결과 반환
+- 대화 기록/세션 관리 및 카테고리 처리 로직 개선
+
+---


### PR DESCRIPTION
## 파인튜닝 모델 데이터 학습 진행

## 챗봇 프롬프트(LLM_chatbot_base_info_model.py, LLM_chatbot_free_text_model.py) 변경
- 프롬프트를 **한글 100%**로, recommend/challenges 등 모든 출력이 반드시 한글로만 나오도록 강하게 명시
- 반드시 하나의 올바른 JSON 객체만 출력, recommend(문자열)와 challenges(객체 배열)만 최상위 필드로
- challenges 각 항목의 title/description도 한글로만, 영어/숫자/특수문자/이모지/마크다운/코드블록 등 사용 금지
- JSON 외의 어떤 텍스트도 출력 금지, recommend/challenges 중첩/문자열 등 잘못된 구조 방지
- 예시 출력({escaped_format}) 포함, 프롬프트 내 지침 강화

## 라우터 코드(chatbot_router.py) 변경
- SSE 응답에서 LLM 응답 파싱 및 검증 로직 개선
- event: "challenge"/"close"/"error" 등 이벤트별로 JSON 파싱 및 에러 처리 강화
- 최종 응답에서 반드시 challenges가 리스트로 포함되어 있는지 검증
- base-info/free-text 모두 동일한 구조로 챌린지 추천 결과 반환
- 대화 기록/세션 관리 및 카테고리 처리 로직 개선